### PR TITLE
Fix package.json module names

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "break_eternity.js",
   "version": "1.2.4",
   "description": "A Javascript numerical library to represent numbers as large as 10^^1e308 and as small as 10^-10^^1e308. Sequel to break_infinity.js, designed for incremental games.",
-  "main": "dist/break_infinity.js",
-  "module": "dist/break_infinity.esm.js",
-  "unpkg": "dist/break_infinity.min.js",
+  "main": "dist/break_eternity.js",
+  "module": "dist/break_eternity.esm.js",
+  "unpkg": "dist/break_eternity.min.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "bili",


### PR DESCRIPTION
Sorry @Patashu I can't believe I messed this up in 🤦🏻‍♂️ #42.

The current version in npm is broken because module resolution is looking for `dist/break_infinity.*`. I ran some checks locally to make sure it's working, seems to be.

Once it's merged a new version needs to be published to npm. 

🤦🏻‍♂️🤦🏻‍♂️🤦🏻‍♂️