### PR TITLE
Update lint tooling

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+
+# Distributed files
+break_eternity.*js
+index.d.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,17 +8,15 @@ module.exports = {
     commonjs: true,
     mocha: true
   },
-  plugins: ["@typescript-eslint", "prettier"],
+  plugins: ["@typescript-eslint"],
   extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "prettier",
-    "plugin:prettier/recommended"
   ],
   rules: {
-    "prettier/prettier": ["error"],
     "@typescript-eslint/no-unused-vars": [
       "warn",
       { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+
+# Distributed files
+break_eternity.*js
+index.d.ts

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode", "dbaeumer.vscode-eslint"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "bili": "^5.0.5",
     "eslint": "^7.23.0",
     "eslint-config-prettier": "^8.1.0",
-    "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.23.1",
     "prettier": "^2.2.1",
     "rollup-plugin-typescript2": "^0.31.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "scripts": {
     "build": "bili",
     "prepublishOnly": "npm run build",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "eslint . && prettier --check .",
+    "fix": "prettier --write . && eslint --fix ."
   },
   "files": [
     "dist"


### PR DESCRIPTION
This PR updates the lint tooling and provides two commands to check (`npm run lint`) and fix (`npm run fix`) lint errors. As Prettier runs on almost every file in the repository, this PR doesn't include formatting the whole repo with prettier (by running `npm run fix`).

Additionally, it adds some VS Code configuration files so VS Code users can get automatic formatting with Prettier on save, and eslint errors in their editor.

@bbugh (author of e566d963f37cfed8390480eecdbd28467698be1d) - FYI. This *removes* eslint-plugin-prettier as prettier has its own way of fixing files - and having it enabled causes annoying lint errors when editing files before saving.