### PR TITLE
Fix d_lambertw bugs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -317,7 +317,7 @@ function d_lambertw(z: Decimal, tol = 1e-10): Decimal {
   //Halley's method; see 5.9 in [1]
 
   for (let i = 0; i < 100; ++i) {
-    ew = Decimal.exp(-w);
+    ew = w.neg().exp();
     wewz = w.sub(z.mul(ew));
     wn = w.sub(wewz.div(w.add(1).sub(w.add(2).mul(wewz).div(Decimal.mul(2, w).add(2)))));
     if (Decimal.abs(wn.sub(w)).lt(Decimal.abs(wn).mul(tol))) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -303,10 +303,10 @@ function d_lambertw(z: Decimal, tol = 1e-10): Decimal {
   if (!Number.isFinite(z.mag)) {
     return z;
   }
-  if (z === Decimal.dZero) {
+  if (z.eq(Decimal.dZero)) {
     return z;
   }
-  if (z === Decimal.dOne) {
+  if (z.eq(Decimal.dOne)) {
     //Split out this case because the asymptotic series blows up
     return D(OMEGA);
   }


### PR DESCRIPTION
Notably, `d_lambertw` wasn't working correctly with 0 and 1 as it was using === to convert Decimals instead of `.eq`.

This also fixes a minor Decimal -> number -> Decimal conversion which loses precision (presumably only when `layer > 0`?), as well as generally being a bit slow.