### PR TITLE
Optimise D, FC, FC_NN, ME, MN

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,5 +25,11 @@ module.exports = {
     ],
     "@typescript-eslint/restrict-plus-operands": 0, // A lot of strings are built with +
     "@typescript-eslint/no-this-alias": 0, // `this` is aliased in several places
-  }
+    "@typescript-eslint/unbound-method": [
+      "error",
+      {
+        ignoreStatic: true,
+      },
+    ],
+  },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,25 +178,25 @@ const critical_slog_values = [
   ],
 ];
 
-const D = function D(value: DecimalSource): Decimal {
+let D = function D(value: DecimalSource): Decimal {
   return Decimal.fromValue_noAlloc(value);
 };
 
-const FC = function (sign: number, layer: number, mag: number) {
+let FC = function (sign: number, layer: number, mag: number) {
   return Decimal.fromComponents(sign, layer, mag);
 };
 
-const FC_NN = function FC_NN(sign: number, layer: number, mag: number) {
+let FC_NN = function FC_NN(sign: number, layer: number, mag: number) {
   return Decimal.fromComponents_noNormalize(sign, layer, mag);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const ME = function ME(mantissa: number, exponent: number) {
+let ME = function ME(mantissa: number, exponent: number) {
   return Decimal.fromMantissaExponent(mantissa, exponent);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const ME_NN = function ME_NN(mantissa: number, exponent: number) {
+let ME_NN = function ME_NN(mantissa: number, exponent: number) {
   return Decimal.fromMantissaExponent_noNormalize(mantissa, exponent);
 };
 
@@ -2950,3 +2950,13 @@ for (var i = 0; i < 10; ++i)
 }
 
 // return Decimal;
+
+// Optimise Decimal aliases.
+// We can't do this optimisation before Decimal is assigned.
+D = Decimal.fromValue_noAlloc;
+FC = Decimal.fromComponents;
+FC_NN = Decimal.fromComponents_noNormalize;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+ME = Decimal.fromMantissaExponent;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+ME_NN = Decimal.fromMantissaExponent_noNormalize;


### PR DESCRIPTION
This PR makes those variables point to the original static methods that they are aliasing, avoiding the overhead of a function call.

This PR conflicts with #84 as they both change .eslintrc.js. Choose one to merge first and I'll rebase the other one on top of HEAD (or you can resolve the merge conflicts yourself).