### PR TITLE
Fix setting .m to 0 not setting layer and exponent

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,5 +25,7 @@ module.exports = {
     ],
     "@typescript-eslint/restrict-plus-operands": 0, // A lot of strings are built with +
     "@typescript-eslint/no-this-alias": 0, // `this` is aliased in several places
-  }
+    "no-unused-expressions": "off",
+    "@typescript-eslint/no-unused-expressions": ["error"],
+  },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -395,8 +395,8 @@ export default class Decimal {
       //don't even pretend mantissa is meaningful
       this.sign = Math.sign(value);
       if (this.sign === 0) {
-        this.layer === 0;
-        this.exponent === 0;
+        this.layer = 0;
+        this.exponent = 0;
       }
     }
   }


### PR DESCRIPTION
The two expressions in the if block were no-ops.

To prevent this from happening in the future, this PR also enables eslint's no-unused-expression lint.

This PR conflicts with #83 as they both change .eslintrc.js. Choose one to merge first and I'll rebase the other one on top of HEAD (or you can resolve the merge conflicts yourself).