### PR TITLE
Add cache for fromString

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -495,7 +495,22 @@ export default class Decimal {
    * is required.
    */
   public static fromValue_noAlloc(value: DecimalSource): Readonly<Decimal> {
-    return value instanceof Decimal ? value : new Decimal(value);
+    if (value instanceof Decimal) {
+      return value;
+    } else if (typeof value === "string") {
+      const cached = Decimal.fromStringCache.get(value);
+      if (cached !== undefined) {
+        return cached;
+      }
+      return Decimal.fromString(value);
+    } else if (typeof value === "number") {
+      return Decimal.fromNumber(value);
+    } else {
+      // This should never happen... but some users like Prestige Tree Rewritten
+      // pass undefined values in as DecimalSources, so we should handle this
+      // case to not break them.
+      return Decimal.dZero;
+    }
   }
 
   public static abs(value: DecimalSource): Decimal {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ const NUMBER_EXP_MIN = -324; //The smallest exponent that can appear in a Number
 
 const MAX_ES_IN_A_ROW = 5; //For default toString behaviour, when to swap from eee... to (e^n) syntax.
 
-const DEFAULT_FROM_STRING_CACHE_SIZE = 1 << 10; // The default size of the LRU cache used to cache Decimal.fromString.
+const DEFAULT_FROM_STRING_CACHE_SIZE = 1 << (10 - 1); // The default size of the LRU cache used to cache Decimal.fromString.
 
 const IGNORE_COMMAS = true;
 const COMMAS_ARE_DECIMAL_POINTS = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2127,7 +2127,7 @@ export default class Decimal {
       } else if (Math.abs(b.toNumber() % 2) % 2 === 0) {
         return result;
       }
-      return result;
+      return Decimal.dNaN;
     }
 
     return result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ const NUMBER_EXP_MIN = -324; //The smallest exponent that can appear in a Number
 
 const MAX_ES_IN_A_ROW = 5; //For default toString behaviour, when to swap from eee... to (e^n) syntax.
 
-const DEFAULT_FROM_STRING_CACHE_SIZE = 1 << (10 - 1); // The default size of the LRU cache used to cache Decimal.fromString.
+const DEFAULT_FROM_STRING_CACHE_SIZE = (1 << 10) - 1; // The default size of the LRU cache used to cache Decimal.fromString.
 
 const IGNORE_COMMAS = true;
 const COMMAS_ARE_DECIMAL_POINTS = false;

--- a/src/lru-cache.ts
+++ b/src/lru-cache.ts
@@ -1,0 +1,134 @@
+/**
+ * A LRU cache intended for caching pure functions.
+ */
+export class LRUCache<K, V> {
+  private map = new Map<K, ListNode<K, V>>();
+  // Invariant: Exactly one of the below is true before and after calling a
+  // LRUCache method:
+  // - first and last are both undefined, and map.size() is 0.
+  // - first and last are the same object, and map.size() is 1.
+  // - first and last are different objects, and map.size() is greater than 1.
+  private first: ListNode<K, V> | undefined = undefined;
+  private last: ListNode<K, V> | undefined = undefined;
+  maxSize: number;
+
+  /**
+   * @param maxSize The maximum size for this cache.
+   */
+  constructor(maxSize: number) {
+    this.maxSize = maxSize;
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+
+  /**
+   * Gets the specified key from the cache, or undefined if it is not in the
+   * cache.
+   * @param key The key to get.
+   * @returns The cached value, or undefined if key is not in the cache.
+   */
+  get(key: K): V | undefined {
+    const node = this.map.get(key);
+    if (node === undefined) {
+      return undefined;
+    }
+    // It is guaranteed that there is at least one item in the cache.
+    // Therefore, first and last are guaranteed to be a ListNode...
+    // but if there is only one item, they might be the same.
+
+    // Update the order of the list to make this node the first node in the
+    // list.
+    // This isn't needed if this node is already the first node in the list.
+    if (node !== this.first) {
+      // As this node is DIFFERENT from the first node, it is guaranteed that
+      // there are at least two items in the cache.
+      // However, this node could possibly be the last item.
+      if (node === this.last) {
+        // This node IS the last node.
+        this.last = node.prev;
+        // From the invariants, there must be at least two items in the cache,
+        // so node - which is the original "last node" - must have a defined
+        // previous node. Therefore, this.last - set above - must be defined
+        // here.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this.last!.next = undefined;
+      } else {
+        // This node is somewhere in the middle of the list, so there must be at
+        // least THREE items in the list, and this node's prev and next must be
+        // defined here.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        node.prev!.next = node.next;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        node.next!.prev = node.prev;
+      }
+      node.next = this.first;
+      // From the invariants, there must be at least two items in the cache, so
+      // this.first must be a valid ListNode.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.first!.prev = node;
+      this.first = node;
+    }
+    return node.value;
+  }
+
+  /**
+   * Sets an entry in the cache.
+   *
+   * @param key The key of the entry.
+   * @param value The value of the entry.
+   * @throws Error, if the map already contains the key.
+   */
+  set(key: K, value: V): void {
+    // Ensure that this.maxSize >= 1.
+    if (this.maxSize < 1) {
+      return;
+    }
+    if (this.map.has(key)) {
+      throw new Error("Cannot update existing keys in the cache");
+    }
+    const node = new ListNode(key, value);
+    // Move node to the front of the list.
+    if (this.first === undefined) {
+      // If the first is undefined, the last is undefined too.
+      // Therefore, this cache has no items in it.
+      this.first = node;
+      this.last = node;
+    } else {
+      // This cache has at least one item in it.
+      node.next = this.first;
+      this.first.prev = node;
+      this.first = node;
+    }
+    this.map.set(key, node);
+
+    while (this.map.size > this.maxSize) {
+      // We are guaranteed that this.maxSize >= 1,
+      // so this.map.size is guaranteed to be >= 2,
+      // so this.first and this.last must be different valid ListNodes,
+      // and this.last.prev must also be a valid ListNode (possibly this.first).
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const last = this.last!;
+      this.map.delete(last.key);
+      this.last = last.prev;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.last!.next = undefined;
+    }
+  }
+}
+
+/**
+ * A node in a doubly linked list.
+ */
+class ListNode<K, V> {
+  key: K;
+  value: V;
+  next: ListNode<K, V> | undefined = undefined;
+  prev: ListNode<K, V> | undefined = undefined;
+
+  constructor(key: K, value: V) {
+    this.key = key;
+    this.value = value;
+  }
+}

--- a/src/lru-cache.ts
+++ b/src/lru-cache.ts
@@ -13,7 +13,12 @@ export class LRUCache<K, V> {
   maxSize: number;
 
   /**
-   * @param maxSize The maximum size for this cache.
+   * @param maxSize The maximum size for this cache. We recommend setting this
+   * to be one less than a power of 2, as most hashtables - including V8's
+   * Object hashtable (https://crsrc.org/c/v8/src/objects/ordered-hash-table.cc)
+   * - uses powers of two for hashtable sizes. It can't exactly be a power of
+   * two, as a .set() call could temporarily set the size of the map to be
+   * maxSize + 1.
    */
   constructor(maxSize: number) {
     this.maxSize = maxSize;


### PR DESCRIPTION
In Prestige Tree Rewritten, Decimal.fromString takes 16% of scripting time, mostly called from the constructor (which is called from D). Strings constants are passed into Decimal methods, which get converted into new Decimals using D.

These string constants are being converted into strings every time those methods are called. To fix this, Prestige Tree Rewritten could instead pre-convert all string constants used to be Decimals, then use those Decimals instead. However, that would require a LOT of new code and would be unwieldy to use.

Instead, we can implement caching for fromString from break_eternity.js's end. This reduces the aforementioned 16% of scripting time down to 0.6% without changing a line of game code.

This PR introduces a simple LRU cache that I whipped up. It has the ability to change size on-demand by setting `Decimal.fromStringCache.maxSize`, but we currently don't expose this to users.

The default cache size is mostly arbitrary (1023) and could be changed to another (power of 2) - 1.