### PR TITLE
Fix fractional powers with negative numbers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3131,7 +3131,7 @@ export default class Decimal {
       const sign2 = Math.abs(b.recip().toNumber() % 2) % 2;
       if (sign1 === 1 || sign2 === 1) {
         return result.neg();
-      } else if (sign1 === 0 || sign2 === 0) {
+      } else if (sign1 === 0) {
         return result;
       }
       return FC_NN(Number.NaN, Number.NaN, Number.NaN);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3127,9 +3127,11 @@ export default class Decimal {
     const result = a.absLog10().mul(b).pow10();
 
     if (this.sign === -1) {
-      if (Math.abs(b.toNumber() % 2) % 2 === 1) {
+      const sign1 = Math.abs(b.toNumber() % 2) % 2;
+      const sign2 = Math.abs(b.recip().toNumber() % 2) % 2;
+      if (sign1 === 1 || sign2 === 1) {
         return result.neg();
-      } else if (Math.abs(b.toNumber() % 2) % 2 === 0) {
+      } else if (sign1 === 0 || sign2 === 0) {
         return result;
       }
       return FC_NN(Number.NaN, Number.NaN, Number.NaN);

--- a/src/unit_tests.js
+++ b/src/unit_tests.js
@@ -585,4 +585,5 @@ var all_tests = function()
   test_tetrate_increasing();
   test_penta_log();
   test_linear_penta_root();
+  test_fractional_negative_powers();
 }

--- a/src/unit_tests.js
+++ b/src/unit_tests.js
@@ -543,6 +543,18 @@ var test_linear_penta_root = function()
   }
 }
 
+var test_fractional_negative_powers = function()
+{
+  console.log("test_fractional_negative_powers");
+  for (var i = 0; i < 1000; ++i)
+  {
+    let num = new Decimal(-Math.ceil(Math.random() * 1000));
+    let pow = Math.floor(Math.random() * 5) * 2 + 1;
+    let result = num.pow(1 / pow);
+    assert_eq_tolerance(num + " rooted by " + pow + " is " + result, result.pow(pow), num);
+  }
+}
+
 var all_tests = function()
 {
   test_tetrate_ground_truth();


### PR DESCRIPTION
Currently, raising negative powers to a fraction is broken in b_e. This PR addresses this issue.

For example, `new Decimal(-8).cbrt()` and `new Decimal(-8).pow(1/3)` both return `NaN` instead of `-2`.

This PR would fix this behavior, so both of the examples will return `-2` instead of `NaN`.

New tests testing this behavior have been added.